### PR TITLE
`esm-lint.yml`: remove unnecessary use of `cat`

### DIFF
--- a/esm-lint/esm-lint.yml
+++ b/esm-lint/esm-lint.yml
@@ -20,7 +20,7 @@ jobs:
       - run: npm install
       - run: npm run build --if-present
       - run: npm pack --dry-run
-      - run: npm pack --silent 2>/dev/null | xargs cat | tar -xz
+      - run: npm pack --silent 2>/dev/null | xargs -n1 tar -xzf
       - uses: actions/upload-artifact@v2
         with:
           path: package


### PR DESCRIPTION
I'm aware that this is a _very substantial change_ but at least it makes it a bit easier to parse that pipeline :upside_down_face: 