### PR TITLE
`webext/release.yml`: Make the workflow self-contained

### DIFF
--- a/webext/release.yml
+++ b/webext/release.yml
@@ -48,7 +48,7 @@ jobs:
         run: npm ci || npm install
       - run: npm run build
       - name: Update extension’s meta
-        run: npx dot-json $DIRECTORY/manifest.json version ${{ needs.Version.outputs.version }}
+        run: npx dot-json@1 $DIRECTORY/manifest.json version ${{ needs.Version.outputs.version }}
       - name: Submit
         run: |
           case ${{ matrix.command }} in

--- a/webext/release.yml
+++ b/webext/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+env:
+  DIRECTORY: distribution
+
 on:
   workflow_dispatch:
   # You can manually trigger a deployment on GitHub.com
@@ -45,8 +48,17 @@ jobs:
         run: npm ci || npm install
       - run: npm run build
       - name: Update extension’s meta
-        run: npx dot-json distribution/manifest.json version ${{ needs.Version.outputs.version }}
-      - run: npm run release:${{ matrix.command }}
+        run: npx dot-json $DIRECTORY/manifest.json version ${{ needs.Version.outputs.version }}
+      - name: Submit
+        run: |
+          case ${{ matrix.command }} in
+            chrome)
+              cd $DIRECTORY && npx chrome-webstore-upload-cli@1 upload --auto-publish
+              ;;
+            firefox)
+              cd $DIRECTORY && npx web-ext-submit@5
+              ;;
+          esac
         env:
           EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}


### PR DESCRIPTION
Until now, the workflow required 2 npm scripts and 2 dependencies defined in package.json. This changes makes the workflow self-contained so one doesn't have to install the heavy `web-ext` dependency locally (with its 1080 deps)

This workflow has been tested in https://github.com/GhostText/GhostText/blob/d8703b5d5cdea5b5212720cb4bdacbd99e0cc590/.github/workflows/release.yml