### PR TITLE
`webext`: Update uploader

### DIFF
--- a/webext/release.yml
+++ b/webext/release.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           case ${{ matrix.command }} in
             chrome)
-              cd $DIRECTORY && npx chrome-webstore-upload-cli@1 upload --auto-publish
+              cd $DIRECTORY && npx chrome-webstore-upload-cli@2 upload --auto-publish
               ;;
             firefox)
               cd $DIRECTORY && npx web-ext-submit@6
@@ -62,7 +62,6 @@ jobs:
         env:
           EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
           WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}
           WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_API_SECRET }}


### PR DESCRIPTION
Updates the tempalte to latest version of https://github.com/fregante/chrome-webstore-upload-cli

Also, removes the `CLIENT_SECRET` env, which is no longer needed