### PR TITLE
`webext` Add CLIENT_SECRET to web extension release workflow

### DIFF
--- a/webext/release.yml
+++ b/webext/release.yml
@@ -62,6 +62,7 @@ jobs:
         env:
           EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
           WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}
           WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_API_SECRET }}


### PR DESCRIPTION
Following [this addition](https://github.com/fregante/chrome-webstore-upload-cli/commit/e7d5e1a9863090380b1a0a1a5bc5b7fa37ba0ac8) I propose an update of the workflow.